### PR TITLE
Update CellMeasurer.DynamicHeightTableColumn.example.js

### DIFF
--- a/source/CellMeasurer/CellMeasurer.DynamicHeightTableColumn.example.js
+++ b/source/CellMeasurer/CellMeasurer.DynamicHeightTableColumn.example.js
@@ -70,7 +70,6 @@ export default class DynamicHeightTableColumn extends React.PureComponent {
       <CellMeasurer
         cache={this._cache}
         columnIndex={0}
-        key={dataKey}
         parent={parent}
         rowIndex={rowIndex}>
         <div


### PR DESCRIPTION
Removed 'key' property since it is not included in the documentation and does not appear to make a functional difference.
